### PR TITLE
fix: fixed "ConnectionPool->getQueryBuilderForTable() requires a conn…

### DIFF
--- a/Classes/Domain/Repository/CopyrightReferenceRepository.php
+++ b/Classes/Domain/Repository/CopyrightReferenceRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace TGM\TgmCopyright\Domain\Repository;
 
 
@@ -26,6 +27,7 @@ namespace TGM\TgmCopyright\Domain\Repository;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -38,12 +40,13 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
      * @param array $settings
      * @return array|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
-    public function findByRootline($settings) {
+    public function findByRootline($settings)
+    {
 
         $pidClause = $this->getStatementDefaults($settings['rootlines']);
         $additionalClause = '';
 
-        if((int)$settings['displayDuplicateImages']===0) {
+        if ((int)$settings['displayDuplicateImages'] === 0) {
             $additionalClause .= ' GROUP BY file.uid';
         }
 
@@ -59,9 +62,9 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
           LEFT JOIN sys_file_metadata AS meta ON (file.uid=meta.file)
           LEFT JOIN pages AS p ON (ref.pid=p.uid)
           WHERE (ref.copyright IS NOT NULL OR meta.copyright!="")
-          AND p.deleted=0 AND p.hidden=0 AND (p.starttime=0 OR p.starttime<='.$now.') AND (p.endtime=0 OR p.endtime>='.$now.')
+          AND p.deleted=0 AND p.hidden=0 AND (p.starttime=0 OR p.starttime<=' . $now . ') AND (p.endtime=0 OR p.endtime>=' . $now . ')
           AND file.missing=0 AND file.uid IS NOT NULL
-          AND ref.deleted=0 AND ref.hidden=0 AND ref.t3ver_wsid=0 '. $pidClause . $additionalClause;
+          AND ref.deleted=0 AND ref.hidden=0 AND ref.t3ver_wsid=0 ' . $pidClause . $additionalClause;
 
         $preQuery->statement($statement);
 
@@ -71,9 +74,9 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
         $finalRecords = $this->filterPreResultsReturnUids($preResults);
 
         // Final select
-        if(false === empty($finalRecords)) {
+        if (false === empty($finalRecords)) {
             $finalQuery = $this->createQuery();
-            return $finalQuery->statement('SELECT * FROM sys_file_reference WHERE uid IN('.implode(',',$finalRecords).')')->execute();
+            return $finalQuery->statement('SELECT * FROM sys_file_reference WHERE uid IN(' . implode(',', $finalRecords) . ')')->execute();
         } else {
             return [];
         }
@@ -84,7 +87,8 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
      * @param string $rootlines
      * @return array|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
-    public function findForSitemap($rootlines) {
+    public function findForSitemap($rootlines)
+    {
 
         $pidClause = $this->getStatementDefaults($rootlines);
 
@@ -98,9 +102,9 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
           SELECT ref.* FROM sys_file_reference AS ref
           LEFT JOIN sys_file AS file ON (file.uid=ref.uid_local)
           LEFT JOIN pages AS p ON (ref.pid=p.uid)
-          WHERE p.deleted=0 AND p.hidden=0 AND (p.starttime=0 OR p.starttime<='.$now.') AND (p.endtime=0 OR p.endtime>='.$now.')
+          WHERE p.deleted=0 AND p.hidden=0 AND (p.starttime=0 OR p.starttime<=' . $now . ') AND (p.endtime=0 OR p.endtime>=' . $now . ')
           AND file.missing=0 AND file.uid IS NOT NULL AND (file.type=2 OR file.type=5)
-          AND ref.deleted=0 AND ref.hidden=0 AND ref.t3ver_wsid=0 '. $pidClause;
+          AND ref.deleted=0 AND ref.hidden=0 AND ref.t3ver_wsid=0 ' . $pidClause;
 
         $preQuery->statement($statement);
 
@@ -110,9 +114,9 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
         $finalRecords = $this->filterPreResultsReturnUids($preResults);
 
         // Final select
-        if(false === empty($finalRecords)) {
+        if (false === empty($finalRecords)) {
             $finalQuery = $this->createQuery();
-            return $finalQuery->statement('SELECT * FROM sys_file_reference WHERE uid IN('.implode(',',$finalRecords).')')->execute();
+            return $finalQuery->statement('SELECT * FROM sys_file_reference WHERE uid IN(' . implode(',', $finalRecords) . ')')->execute();
         } else {
             return null;
         }
@@ -124,12 +128,13 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
      * @param array $preResults raw sql results to filter
      * @return array
      */
-    public function filterPreResultsReturnUids($preResults) {
+    public function filterPreResultsReturnUids($preResults)
+    {
 
         $finalRecords = [];
 
-        foreach($preResults as $preResult) {
-            if(isset($preResult['tablenames']) && isset($preResult['uid_foreign'])) {
+        foreach ($preResults as $preResult) {
+            if ((isset($preResult['tablenames']) && isset($preResult['uid_foreign'])) && (strlen($preResult['tablenames']) > 0 && strlen($preResult['uid_foreign']) > 0)) {
 
                 /*
                  * Thanks to the QueryBuilder we don't have to check end- and starttime, deleted, hidden manually before because of the default RestrictionContainers
@@ -143,7 +148,7 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
                         $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($preResult['uid_foreign']))
                     )->execute()->fetch();
 
-                if($foreignRecord === false || $foreignRecord === false) {
+                if ($foreignRecord === false || $foreignRecord === false) {
                     // Exlude if nothing found
                     continue;
                 }
@@ -160,13 +165,14 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
      * @param string $rootlines
      * @return string
      */
-    public function getStatementDefaults($rootlines) {
-        $rootlines = (string) $rootlines;
+    public function getStatementDefaults($rootlines)
+    {
+        $rootlines = (string)$rootlines;
         $context = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Context\Context::class);
-        $sysLanguage = (int) $context->getPropertyFromAspect('language', 'id');
+        $sysLanguage = (int)$context->getPropertyFromAspect('language', 'id');
         $defaultStatement = ' AND ref.sys_language_uid=' . $sysLanguage;
-        if($rootlines!=='') {
-            $defaultStatement .= ' AND ref.pid IN('.$this->extendPidListByChildren($rootlines).')';
+        if ($rootlines !== '') {
+            $defaultStatement .= ' AND ref.pid IN(' . $this->extendPidListByChildren($rootlines) . ')';
         } else {
             $defaultStatement .= '';
         }


### PR DESCRIPTION
It can happen that the `tablesnames` of `$preResult` is empty. This leads to the Excpetion `UnexpectedValueException: ConnectionPool->getQueryBuilderForTable() requires a connection name to be provided.` thrown by the Typo3 API.