### PR TITLE
Update CopyrightReferenceRepository.php

### DIFF
--- a/Classes/Domain/Repository/CopyrightReferenceRepository.php
+++ b/Classes/Domain/Repository/CopyrightReferenceRepository.php
@@ -99,6 +99,9 @@ class CopyrightReferenceRepository extends \TYPO3\CMS\Extbase\Persistence\Reposi
             $queryBuilder->expr()->eq('missing', 0),
             $queryBuilder->expr()->isNotNull('file.uid'),
             $queryBuilder->expr()->in('file.type', [2, 5]),
+            $queryBuilder->expr()->eq('p.no_index', 0),
+            $queryBuilder->expr()->eq('p.no_follow', 0),
+            $queryBuilder->expr()->eq('p.hidden’, 0),
         ];
 
         if ('' !== $rootlines) {


### PR DESCRIPTION
Added no_index, no_follow and hidden query to the query in the findForSitemap-function. 

This should resolve the issue: Exclude images on pages with NOINDEX in XML image sitemap #49