### PR TITLE
Unify SQL definitions with TYPO3 core

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,12 +2,12 @@
 # Table structure for table 'sys_file_reference'
 #
 CREATE TABLE sys_file_reference (
-	copyright varchar(255) DEFAULT NULL
+    copyright text
 );
 
 #
 # Table structure for table 'sys_file_metadata'
 #
 CREATE TABLE sys_file_metadata (
-    copyright varchar(255) DEFAULT '' NOT NULL
+    copyright text
 );


### PR DESCRIPTION
Hi 👋  
The SQL definitions differ from the TYPO3 core's definition for the copyright field. This leads to an error while updating the database schema, in case the sys_file_metadata copyright field already contains NULL values. 